### PR TITLE
Make client info path optional

### DIFF
--- a/DHCPServer/Library/DHCPClientInformation.cs
+++ b/DHCPServer/Library/DHCPClientInformation.cs
@@ -39,7 +39,7 @@ namespace GitHub.JPMikkers.DHCP
         {
             DHCPClientInformation result;
 
-            if(File.Exists(file))
+            if(file != null && File.Exists(file))
             {
                 using(Stream s = File.OpenRead(file))
                 {

--- a/DHCPServer/Library/DHCPServer.cs
+++ b/DHCPServer/Library/DHCPServer.cs
@@ -199,24 +199,27 @@ namespace GitHub.JPMikkers.DHCP
                         clientInformation.Clients.Add(client);
                     }
 
-                    for(int t = 0; t < ClientInformationWriteRetries; t++)
+                    if(_clientInfoPath != null)
                     {
-                        try
+                        for(int t = 0; t < ClientInformationWriteRetries; t++)
                         {
-                            clientInformation.Write(_clientInfoPath);
-                            break;
-                        }
-                        catch
-                        {
-                        }
+                            try
+                            {
+                                clientInformation.Write(_clientInfoPath);
+                                break;
+                            }
+                            catch
+                            {
+                            }
 
-                        if(t < ClientInformationWriteRetries)
-                        {
-                            Thread.Sleep(_random.Next(500, 1000));
-                        }
-                        else
-                        {
-                            Trace("Could not update client information, data might be stale");
+                            if(t < ClientInformationWriteRetries)
+                            {
+                                Thread.Sleep(_random.Next(500, 1000));
+                            }
+                            else
+                            {
+                                Trace("Could not update client information, data might be stale");
+                            }
                         }
                     }
                 }

--- a/DHCPServer/Library/DHCPServer.cs
+++ b/DHCPServer/Library/DHCPServer.cs
@@ -230,6 +230,9 @@ namespace GitHub.JPMikkers.DHCP
             }
         }
 
+        public DHCPServer(ILogger logger, IUDPSocketFactory udpSocketFactory) : this(logger, null, udpSocketFactory)
+        { }
+
         public DHCPServer(ILogger logger, string clientInfoPath, IUDPSocketFactory udpSocketFactory)
         {
             _updateClientInfoQueue = new AutoPumpQueue<int>(OnUpdateClientInfo);


### PR DESCRIPTION
Not everyone wants to read/write client info to disk using the library (I serialize clients myself). If null is passed to client path, read/write could be skipped.