### PR TITLE
Handle exceptions during receive and dispose timer

### DIFF
--- a/DHCPServer/Library/DHCPServer.cs
+++ b/DHCPServer/Library/DHCPServer.cs
@@ -876,7 +876,7 @@ namespace GitHub.JPMikkers.DHCP
                 }
                 catch
                 {
-                    return;
+                    // Ignored.
                 }
             }
         }


### PR DESCRIPTION
Exceptions weren't handled properly, causing them to appear in UnobservedTaskException.
Also the Timer created during MainTask wasn't disposed. I've split this up in two methods to greatly simplify the logic.